### PR TITLE
added method to add PAC files. Updated method for 6.2 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,8 @@
-v3.7 ( TO BE RELEASED)
+v3.7 ( OCTOBER)
 =========================
 Updated add_url_categories method to support Custom IP Ranges  and IP Ranges Retaining Parent Category (by `Sergio Pereira <mailto:spereira@zscaler.com>`_)
+Updated method add_ipDestinationGroups to support domain option due to 6.2 release
+Added method to add PAC files
 
 v3.6 ( AUGUST 2022)
 =========================

--- a/helpers/http_calls.py
+++ b/helpers/http_calls.py
@@ -68,12 +68,12 @@ class HttpCalls(object):
                 if headers:
                     self.headers.update(headers)
                 response = requests.post(url=full_url, headers=self.headers, cookies=cookies, json=payload,
-                                         verify=self.verify)
+                                         verify=self.verify)          
             if error_handling:
                 self._zia_http_codes(response)
             else:
                 if response.status_code not in [200, 201, 204]:
-                    raise ValueError(response.status_code)
+                    raise ValueError(f'{response.status_code} -> {response.content}')
             return response
         except requests.HTTPError as e:
             raise ValueError(e)
@@ -151,7 +151,7 @@ class HttpCalls(object):
         :return: None
         """
         if response.status_code in [200, 201, 202, 204]:
-            return
+            return    
         elif response.status_code == 401:
             raise ValueError(f'{response.status_code} :Session is not authenticated or timed out')
         elif response.status_code == 403:

--- a/zia_portaltalker/zia_portaltalker.py
+++ b/zia_portaltalker/zia_portaltalker.py
@@ -70,7 +70,7 @@ class ZiaPortalTalker(object):
 
     def create_dlpEngine(self, payload=None, EngineExpression=None, Name=None, CustomDlpEngine=True,
                          PredefinedEngineName=None, Description=None):
-        '''
+        """
         Method to create a DLP engine
         :param Name: type string. Name of the DLP ENGINE
         :param EngineExpression: type string. Engine Expression
@@ -78,7 +78,7 @@ class ZiaPortalTalker(object):
         :param PredefinedEngineName: type boolean.
         :param Description: type string. Description
         :return: 
-        '''
+        """
         url = '/dlpEngines'
         if payload:
             payload = payload
@@ -101,14 +101,53 @@ class ZiaPortalTalker(object):
         return response
 
     def update_dlpEngine(self, payload, id):
-        '''
+        """
         Method to update a DLP engine
-        :param paylod: type json. payload
+        :param payload: type json. payload
         :return: 
-        '''
+        """
         url = f'/dlpEngines/{id}'
         response = self.hp_http.put_call(url=url, payload=payload, headers=self.headers,
                                          cookies={'JSESSIONID': self.jsessionid,
                                                   'ZS_SESSION_CODE': self.zs_session_code,
                                                   })
         return response
+
+    def list_PacFiles(self):
+        """
+        Method to list PAC files
+        :return: json
+        """
+        url = f'/pacFiles'
+        response = self.hp_http.get_call(url=url, headers=self.headers,
+                                         cookies={'JSESSIONID': self.jsessionid,
+                                                  'ZS_SESSION_CODE': self.zs_session_code,
+                                                  })
+        return response.json()
+
+    def add_PacFile(self, name, description, domain, PacContent, editable=True, pacUrlObfuscated=True):
+        """
+        Method to Add a PAC file
+        :param name: type string. Name of the PAC
+        :param description: type string. Description
+        :param domain: type string. Domain
+        :param PacContent: Type string: PAC content
+        :param editable: Type boolean. Default True
+        :param pacUrlObfuscated: Type boolean. Default True
+        :return:
+        """
+        payload = {
+            'name': name,
+            'editable': editable,
+            'pacContent': PacContent,
+            'pacUrlObfuscated': pacUrlObfuscated,
+            'domain': domain,
+            'description': description,
+            'pacVerificationStatus': 'VERIFY_NOERR'
+        }
+        url = f'/pacFiles'
+        response = self.hp_http.post_call(url=url, headers=self.headers, payload=payload,
+                                          cookies={'JSESSIONID': self.jsessionid,
+                                                   'ZS_SESSION_CODE': self.zs_session_code,
+                                                   })
+        return response.json()

--- a/zia_talker/zia_talker.py
+++ b/zia_talker/zia_talker.py
@@ -230,6 +230,7 @@ class ZiaTalker(object):
             url = '/urlCategories?customOnly=true'
         else:
             url = '/urlCategories'
+        #return self._obtain_all(url)
         response = self.hp_http.get_call(url, cookies={'JSESSIONID': self.jsessionid}, error_handling=True)
         return response.json()
 
@@ -1291,7 +1292,7 @@ class ZiaTalker(object):
 
     def add_firewallFilteringRules(self, name, order, state, action, description=None, defaultRule=False,
                                    predefined=False, srcIps=None, destAddresses=None, destIpGroups=None,
-                                   srcIpGroups=None, labels=None, rank=0):
+                                   srcIpGroups=None, destIpCategories=None, labels=None,nwServices=None, rank=0):
         """
         :param name: type str,  Name of the Firewall Filtering policy rule ["String"]
         :param order: type int, Rule order number of the Firewall Filtering policy rule
@@ -1304,7 +1305,9 @@ class ZiaTalker(object):
         :param srcIps: type list, List of source IP addresses
         :param destAddresses: type list. List of destination addresses
         :param destIpGroups: type list: List of user-definied destination IP address groups
-        :param srcIpGroups: type list: List of user defined source IP addres groups
+        :param srcIpGroups: type list: List of user defined source IP address groups
+        :param destIpCategories: type list: list of destination IP categories
+        :param nwServices: type list. List of user-defined network services on whih the rule is applied
         :return: Default is false.If set to true, a predefined rule is applied
         """
 
@@ -1332,6 +1335,10 @@ class ZiaTalker(object):
             payload.update(destIpGroups=destIpGroups)
         if labels:
             payload.update(labels=labels)
+        if destIpCategories:
+            payload.update(destIpCategories=destIpCategories)
+        if nwServices:
+            payload.update(nwServices=nwServices)
         response = self.hp_http.post_call(url, payload=payload, cookies={'JSESSIONID': self.jsessionid},
                                           error_handling=True)
         return response
@@ -1440,7 +1447,7 @@ class ZiaTalker(object):
     def add_ipDestinationGroups(self, name, type, addresses, ipCategories=None, countries=None, description=None):
         """
         :param name: mame
-        :param type: Destination IP group type. Either DSTN_IP or DSTN_FQDN
+        :param type: Destination IP group type. Either DSTN_IP or  DSTN_FQDN or DSTN_DOMAIN
         :param addresses: List of Destination IP addresses within the group.
         :param description: description
         :param ipCategories: List of Destination IP address URL categories. You can identify destination based
@@ -1448,7 +1455,7 @@ class ZiaTalker(object):
         :param countries: list of destination IP address countries. You can identify destinations based on the location
         of a server.Default value ANY
         """
-        if type not in ["DSTN_IP", "DSTN_FQDN"]:
+        if type not in ["DSTN_IP", "DSTN_FQDN", "DSTN_DOMAIN"]:
             raise ValueError("Invalid destination type ")
         if countries:
             for i in countries:


### PR DESCRIPTION
Updated add_url_categories method to support Custom IP Ranges  and IP Ranges Retaining Parent Category (by `Sergio Pereira <mailto:spereira@zscaler.com>`_)
Updated method add_ipDestinationGroups to support domain option due to 6.2 release
Added method to add PAC files