### PR TITLE
Fixes and Features

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Feat: Added several methods to ZiaPortal Talker (by `Sergio Pereira <mailto:sper
 Feat: ZiaPortal Talker now accepts cookies as authentication  (by `Sergio Pereira <mailto:spereira@zscaler.com>`_)
 Fix: Renamed ZccTalker to ClientConnectorTalker. (by `Dax Mickelson <mailto: dmickelson@zscaler.com>`_)
 Style: Rename files and folders to reduce redundancies. (by `Dax Mickelson <mailto: dmickelson@zscaler.com>`_)
+Fix: Add list object for adding url categories in ZiaTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
+Fix: Add kwargs for url filtering rule to allow for dictionary pass in (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
+Feat: Added method to update pre-exisiting url filtering rule (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
+Fix: Fixed add_rule_label method in ZiaTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
+Feat: Add delete_rule_label method for ZiaTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
+Feat: Add generic PUT, POST, GET, DELETE calls for ZiaPortalTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
 
 v4.1.1 ( July 2023 )
 =========================

--- a/zscaler_api_talkers/zia/portal_talker.py
+++ b/zscaler_api_talkers/zia/portal_talker.py
@@ -804,3 +804,18 @@ class ZiaPortalTalker(object):
         )
 
         return response.json()
+
+    def generic_post(self, url, **kwargs) -> json:
+        url = url
+        payload = kwargs
+        response = self.hp_http.post_call(
+            url=url,
+            headers=self.headers,
+            cookies={
+                "JSESSIONID": self.j_session_id,
+                "ZS_SESSION_CODE": self.zs_session_code,
+            },
+            payload=payload
+        )
+
+        return response.json()

--- a/zscaler_api_talkers/zia/portal_talker.py
+++ b/zscaler_api_talkers/zia/portal_talker.py
@@ -804,8 +804,33 @@ class ZiaPortalTalker(object):
         )
 
         return response.json()
+    
+    def update_eun(self, **kwargs) -> json:
+        """
+        Method to update the EUN settings for a ZIA Tenant
+
+        :return: (json)
+        """
+        url = "/eun"
+        payload = kwargs
+        response = self.hp_http.put_call(
+            url=url,
+            headers=self.headers,
+            cookies={
+                "JSESSIONID": self.j_session_id,
+                "ZS_SESSION_CODE": self.zs_session_code,
+            },
+            payload=payload
+        )
+
+        return response.json()
 
     def generic_post(self, url, **kwargs) -> json:
+        """
+        Generic POST method
+
+        :return: (json)
+        """
         url = url
         payload = kwargs
         response = self.hp_http.post_call(
@@ -816,6 +841,62 @@ class ZiaPortalTalker(object):
                 "ZS_SESSION_CODE": self.zs_session_code,
             },
             payload=payload
+        )
+
+        return response.json()
+
+    def generic_put(self, url, **kwargs) -> json:
+        """
+        Generic PUT method
+
+        :return: (json)
+        """
+        url = url
+        payload = kwargs
+        response = self.hp_http.put_call(
+            url=url,
+            headers=self.headers,
+            cookies={
+                "JSESSIONID": self.j_session_id,
+                "ZS_SESSION_CODE": self.zs_session_code,
+            },
+            payload=payload
+        )
+
+        return response.json()
+
+    def generic_get(self, url) -> json:
+        """
+        Generic GET method
+
+        :return: (json)
+        """
+        url = url
+        response = self.hp_http.get_call(
+            url=url,
+            headers=self.headers,
+            cookies={
+                "JSESSIONID": self.j_session_id,
+                "ZS_SESSION_CODE": self.zs_session_code,
+            }
+        )
+
+        return response.json()
+
+    def generic_delete(self, url) -> json:
+        """
+        Generic DELETE method
+
+        :return: (json)
+        """
+        url = url
+        response = self.hp_http.delete_call(
+            url=url,
+            headers=self.headers,
+            cookies={
+                "JSESSIONID": self.j_session_id,
+                "ZS_SESSION_CODE": self.zs_session_code,
+            }
         )
 
         return response.json()

--- a/zscaler_api_talkers/zia/talker.py
+++ b/zscaler_api_talkers/zia/talker.py
@@ -405,6 +405,7 @@ class ZiaTalker(object):
             "ipRanges": ip_ranges,
             "ipRangesRetainingParentCategory": ip_ranges_retaining_parent_category,
             "type": type_list,
+            "description": description
         }
         response = self.hp_http.post_call(
             url,

--- a/zscaler_api_talkers/zia/talker.py
+++ b/zscaler_api_talkers/zia/talker.py
@@ -392,6 +392,12 @@ class ZiaTalker(object):
         if super_category not in super_categories:
             logger.error(f"Invalid Super Category: {super_categories}")
             raise ValueError("Invalid super category")
+        
+        if keywords is None:
+            keywords = []
+
+        if ip_ranges is None:
+            ip_ranges = []
 
         url = "/urlCategories"
         payload = {
@@ -664,6 +670,7 @@ class ZiaTalker(object):
         validity_time_zone_id=None,
         cbi_profile_id: int = 0,
         block_override: bool = False,
+        **kwargs
     ) -> json:
         """
          Adds a URL Filtering Policy rule. If you are using the Rank feature, refer to About Admin Rank to
@@ -721,6 +728,7 @@ class ZiaTalker(object):
             "rank": rank,
             "action": action,
         }
+        payload.update(kwargs)
         if locations:
             payload.update(locations=locations)
         if location_groups:
@@ -749,9 +757,9 @@ class ZiaTalker(object):
         return response.json()
 
     def update_url_filtering_rules(self, id: int, **kwargs) -> json:
-        url = f"/urlFilteringRules/{str(id)}"
+        url = f"/urlFilteringRules/{id}"
         payload = kwargs
-        response = self.hp_http.post_call(
+        response = self.hp_http.put_call(
             url,
             payload=payload,
             cookies=self.cookies,
@@ -760,6 +768,7 @@ class ZiaTalker(object):
         )
 
         return response.json()
+
     # User Management
 
     def list_departments(
@@ -2418,7 +2427,8 @@ class ZiaTalker(object):
 
     def add_rule_label(
         self,
-        payload: dict,
+        name: str,
+        description: str = ""
     ) -> json:
         """
         Adds new rule labels with the given name
@@ -2427,6 +2437,10 @@ class ZiaTalker(object):
         :param payload: (dict)
         """
         url = "/ruleLabels"
+        payload = {
+            "name": name,
+            "description": description
+        }
         response = self.hp_http.post_call(
             url,
             cookies=self.cookies,
@@ -2436,6 +2450,16 @@ class ZiaTalker(object):
         )
 
         return response.json()
+
+    def delete_rule_label(self, id: str):
+        url = f"/ruleLabels/{id}"
+        response = self.hp_http.delete_call(
+            url,
+            cookies=self.cookies,
+            error_handling=True,
+            headers=self.headers
+        )
+        return response
 
     def update_call(
         self,

--- a/zscaler_api_talkers/zia/talker.py
+++ b/zscaler_api_talkers/zia/talker.py
@@ -746,6 +746,18 @@ class ZiaTalker(object):
 
         return response.json()
 
+    def update_url_filtering_rules(self, id: int, **kwargs) -> json:
+        url = f"/urlFilteringRules/{str(id)}"
+        payload = kwargs
+        response = self.hp_http.post_call(
+            url,
+            payload=payload,
+            cookies=self.cookies,
+            error_handling=True,
+            headers=self.headers,
+        )
+
+        return response.json()
     # User Management
 
     def list_departments(

--- a/zscaler_api_talkers/zia/talker.py
+++ b/zscaler_api_talkers/zia/talker.py
@@ -363,6 +363,7 @@ class ZiaTalker(object):
         custom_category: bool = False,
         ip_ranges: list = None,
         ip_ranges_retaining_parent_category: list = None,
+        description: str = None
     ) -> json:
         """
          Adds a new custom URL category.


### PR DESCRIPTION
Fix: Add list object for adding url categories in ZiaTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
Fix: Add kwargs for url filtering rule to allow for dictionary pass in (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
Feat: Added method to update pre-exisiting url filtering rule (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
Fix: Fixed add_rule_label method in ZiaTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
Feat: Add delete_rule_label method for ZiaTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)
Feat: Add generic PUT, POST, GET, DELETE calls for ZiaPortalTalker (by `Ryan Ulrick <mailto: rulrick@zscaler.com>`_)